### PR TITLE
Fixed broken link for Pangara's WP questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Please read the [contribution guidelines](contributing.md) or the [creating a li
 * [Swift interview questions and answers on Swift 5 by Raywenderlich](https://www.raywenderlich.com/762435-swift-interview-questions-and-answers)
 
 ### WordPress
-* [Top 45 WordPress interview questions](https://pangara.com/blog/45-wordpress-interview-questions-and-answers)
+* [Top 45 WordPress interview questions](https://pangara.com/blog/blog45-wordpress-interview-questions-and-answers/)
 * [10 Essential WordPress Interview Questions](https://www.toptal.com/wordpress/interview-questions)
 
 ### TypeScript


### PR DESCRIPTION
Fixed broken link for Pangara's blog post with WordPress interview questions.